### PR TITLE
Add context in gatsby-node.js

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,7 @@
 const cloudinary = require('cloudinary')
 
 exports.sourceNodes = ({ actions, createNodeId, createContentDigest }, configOptions) => {
+    
     const { createNode } = actions
   
     delete configOptions.plugins
@@ -21,7 +22,7 @@ exports.sourceNodes = ({ actions, createNodeId, createContentDigest }, configOpt
         parent: null,
         children: [],
         internal: {
-            type: `CloudinaryMedia`,
+            type: `Media`,
             content: nodeContent,
             contentDigest: createContentDigest(media),
         },
@@ -44,7 +45,13 @@ exports.sourceNodes = ({ actions, createNodeId, createContentDigest }, configOpt
             if(result.resources.length > 0){
                 result.resources.forEach((mediaItem)=>{
                     const nodeData = processMedia(mediaItem)
-                    createNode(nodeData)
+                    console.log(nodeData.public_id)
+                    cloudinary.v2.api.resource(nodeData.public_id,
+                            function(error, result) {
+                                console.log(result, error);
+                                createNode(result)
+                             });
+                    //createNode(nodeData)
                     console.log("Created Cloudinary file node")
                 })  
             }else{
@@ -52,6 +59,7 @@ exports.sourceNodes = ({ actions, createNodeId, createContentDigest }, configOpt
             }
             if(error){console.log(error)}
             
-        })
-    )
+                })
+            )
+    
   }


### PR DESCRIPTION
Hello,

I used your plugin from gatsby to retrieve photos from Cloudinary into my personal Web.
I have been able to do that with the photos, but I haven't been able to retrieve the metadata title (caption)  for each photo.
I forked your code and make some changes in gatsby-node.js:
I have nested within **cloudinary.v2.api.resources**  **cloudinary.v2.api.resource** to extract 
the field context: {
        custom: {
            alt: "Tower Eifel",
            caption: "Tower Eiffel"
        }
}
and create a new node including those fields.
I can see the context field with console.log but when checking with graphql I can't see anything new. And apart I think that I did wrongly nesting promises, instead of using the promises way (command(argument).then(result=>{return result}).

So, I ask for a modification of code resulting in these new fields:
  context: {custom:{caption:"something written here"}}
I tried something, but I am not a experienced developer.
Thank you.