### PR TITLE
adds support for transformations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,11 @@
   "requires": true,
   "dependencies": {
     "cloudinary": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-1.11.0.tgz",
-      "integrity": "sha512-U5j9aWaYrSteboC7KcFZhvWy734d60CrrEUHVMpCtKhEWxpxXyVSe4Ag1BnRaVVq0YOvlJpXe6Qt6hAcb+h1lg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-1.15.0.tgz",
+      "integrity": "sha512-31E7i7BOVOPfr1uLJhmuK2ZnBvlNv5+/RXmcfUn06kao03aSWDwQ4AuybQiem90jTwMXf2QX3L1f0RVkCbdQ7w==",
       "requires": {
-        "lodash": "^4.17.4",
+        "lodash": "^4.17.11",
         "q": "^1.5.1"
       }
     },


### PR DESCRIPTION
-> see Readme

I think, it's quite helpful to have transformation support. Jason's transformer plugin is absolutely ahead of this but it relies on local file nodes. This plugin is powerful when all assets already live on Cloudinary (exactly my use case). Since I have some transformation requirements I'd love to see this go upstream. This PR should be compatible to the current master, the `transformations` config is totally optional.

BTW: the current impl doesn't add any default transformations -> The `splice` operation's result is silently discarded ;) 