### PR TITLE
fix: incorrect type plugin option validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,17 +156,17 @@ module.exports = {
 
 You can find the plugin options in the table below.
 
-| option         | type    | required | default | description                                                                                                                                                                             |
-| -------------- | ------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cloudName`    | string  | true     | n/a     | Cloud name of your Cloudinary account, can be obtained from your [Cloudinary console](https://cloudinary.com/console/). This should be stored and retrieved as an environment variable. |
-| `apiKey`       | string  | true     | na/a    | API Key of your Cloudinary account, can be obtained from your [Cloudinary console](https://cloudinary.com/console/). This should be stored and retrieved as an environment variable.    |
-| `apiSecret`    | string  | true     | n/a     | API Secret of your Cloudinary account, can be obtained from your [Cloudinary console](https://cloudinary.com/console/). This should be stored and retrieved as an environment variable. |
-| `resourceType` | string  | false    | image   | This is the file type. Possible values: image, raw, video. Note: Use the video resource type for all video resources as well as for audio files, such as .mp3.                          |
-| `type`         | string  | false    | all     | This is the storage type: upload, private, authenticated, facebook, twitter, gplus, instagram_name, gravatar, youtube, hulu, vimeo, animoto, worldstarhiphop or dailymotion.            |
-| `maxResults`   | integer | false    | 10      | Max number of resources to return                                                                                                                                                       |
-| `tags`         | boolean | false    | false   | If true, include the list of tag names assigned to each resource                                                                                                                        |
-| `prefix`       | string  | false    | n/a     | Find all resources with a public ID that starts with the given prefix. The resources are sorted by public ID in the response.                                                           |
-| `context`      | boolean | false    | n/a     | Specifies if the context data for the image should be returned. This is useful for retrieving `alt` text or custom metadata in key:value pairs for an image set on Cloudinary.          |
+| option         | type    | required | default | description                                                                                                                                                                                                         |
+| -------------- | ------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cloudName`    | string  | true     | n/a     | Cloud name of your Cloudinary account, can be obtained from your [Cloudinary console](https://cloudinary.com/console/). This should be stored and retrieved as an environment variable.                             |
+| `apiKey`       | string  | true     | na/a    | API Key of your Cloudinary account, can be obtained from your [Cloudinary console](https://cloudinary.com/console/). This should be stored and retrieved as an environment variable.                                |
+| `apiSecret`    | string  | true     | n/a     | API Secret of your Cloudinary account, can be obtained from your [Cloudinary console](https://cloudinary.com/console/). This should be stored and retrieved as an environment variable.                             |
+| `resourceType` | string  | false    | image   | This is the file type. Possible values: image, raw, video. Note: Use the video resource type for all video resources as well as for audio files, such as .mp3.                                                      |
+| `type`         | string  | false    | n/a     | This is the storage type: upload, private, authenticated, facebook, twitter, gplus, instagram_name, gravatar, youtube, hulu, vimeo, animoto, worldstarhiphop or dailymotion. When non given, all types are sourced. |
+| `maxResults`   | integer | false    | 10      | Max number of resources to return                                                                                                                                                                                   |
+| `tags`         | boolean | false    | false   | If true, include the list of tag names assigned to each resource                                                                                                                                                    |
+| `prefix`       | string  | false    | n/a     | Find all resources with a public ID that starts with the given prefix. The resources are sorted by public ID in the response.                                                                                       |
+| `context`      | boolean | false    | n/a     | Specifies if the context data for the image should be returned. This is useful for retrieving `alt` text or custom metadata in key:value pairs for an image set on Cloudinary.                                      |
 
 With `prefix`, you can source only media files from a specific folder. However, you will need to specify `type` and `resourceType` in the config options.
 

--- a/plugin/gatsby-node.js
+++ b/plugin/gatsby-node.js
@@ -9,7 +9,7 @@ exports.pluginOptionsSchema = ({ Joi }) => {
     apiKey: Joi.string().required(),
     apiSecret: Joi.string().required(),
     resourceType: Joi.string().default('image'),
-    type: Joi.string().default('all'),
+    type: Joi.string(),
     maxResults: Joi.number().integer().positive().default(10),
     resultsPerPage: Joi.number()
       .integer()

--- a/plugin/gatsby-node.test.js
+++ b/plugin/gatsby-node.test.js
@@ -66,7 +66,6 @@ describe('pluginOptionsSchema', () => {
       maxResults: 10,
       resultsPerPage: 10,
       tags: false,
-      type: 'all',
     });
   });
 });


### PR DESCRIPTION
`type` was documented with "all" as the default value. This is the correct mental model as an empty `type` will result in fetching all types, but setting it to the string "all" will result it an error.

fixes #39